### PR TITLE
Fixed type-hint for Discount

### DIFF
--- a/src/Mirakl/MMP/Common/Domain/Offer/AbstractOffer.php
+++ b/src/Mirakl/MMP/Common/Domain/Offer/AbstractOffer.php
@@ -29,7 +29,7 @@ use Mirakl\MMP\Common\Domain\Offer\Price\OfferPricing;
  * @method  $this                                 setCurrencyIsoCode(string $currencyIsoCode)
  * @method  string                                getDescription()
  * @method  $this                                 setDescription(string $description)
- * @method  Discount                              getDiscount()
+ * @method  Discount|null                         getDiscount()
  * @method  int                                   getFavoriteRank()
  * @method  $this                                 setFavoriteRank(int $favoriteRank)
  * @method  Fulfillment                           getFulfillment()


### PR DESCRIPTION
If an offer has no discount, then `Mirakl\MMP\Common\Domain\Offer\AbstractOffer::getDiscount` will return `NULL`. This is not documented in the type-hint, which subsequently causes problems with PHPStan and co.