### PR TITLE
fix phpunit compatibility

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -29,7 +29,7 @@
         }
     },
     "require": {
-        "php": ">=7.2.0",
+        "php": ">=7.3.0",
         "ext-curl": "*",
         "guzzlehttp/guzzle": "~6.0 || ~7.0",
         "guzzlehttp/psr7": "~1.7 || ~2.0"


### PR DESCRIPTION
Hey,

at the moment its not possible to resolve dev - dependencies of the package.

`PHPUnit:~9.0` is only compatible with PHP 7.3 and above.
Using PHPUnit 8 is not recommended because it has [reached EOL](https://phpunit.de/supported-versions.html).

Are there any plans to cover the package with unit tests in general?

IMHO the PHP dependency should also be raised to a [supported version](https://www.php.net/supported-versions.php) (`8.1` or `8.2`) 

Let me know if I should raise the dependency any higher. 

Thx Eric