### PR TITLE
Amend documentation for UpdateOffersRequest

### DIFF
--- a/src/Mirakl/MMP/Shop/Request/Offer/UpdateOffersRequest.php
+++ b/src/Mirakl/MMP/Shop/Request/Offer/UpdateOffersRequest.php
@@ -12,7 +12,7 @@ use Mirakl\MMP\OperatorShop\Request\Offer\AbstractUpdateOffersRequest;
  * use Mirakl\MMP\Shop\Client\ShopApiClient;
  * use Mirakl\MMP\Shop\Request\Offer\UpdateOffersRequest;
  * $api = new ShopApiClient('API_URL', 'API_KEY', 'SHOP_ID');
- * $request = new UpdateOffersRequest('SHOP_ID');
+ * $request = new UpdateOffersRequest();
  * $request->setOffers([
  *     [
  *         'shop_sku' => 'AAPL-CHASAW7852',


### PR DESCRIPTION
The code example  * $request = new UpdateOffersRequest('SHOP_ID'); fails as UpdateOffersRequest accepts an array. If you remove the SHOP_ID the code works as expected.